### PR TITLE
Fix /list and /category commands to handle 'in' transactions correctly

### DIFF
--- a/handlers/category_handler.py
+++ b/handlers/category_handler.py
@@ -73,13 +73,26 @@ async def category_command(update, context):
         expenses = []
 
         for txn in response.data:
-            if txn.get("transfer_type") == "out":
-                amount = float(txn.get("transfer_amount", 0))
+            amount = float(txn.get("transfer_amount", 0))
+            transfer_type = txn.get("transfer_type", "in")
+
+            if transfer_type == "out":
+                # Money going out - add to expenses
                 total_spent += amount
                 expenses.append({
                     "date": txn.get("transaction_date"),
                     "amount": amount,
-                    "content": txn.get("content", "")
+                    "content": txn.get("content", ""),
+                    "type": "out"
+                })
+            else:
+                # Money coming in (refund/return) - reduce expenses
+                total_spent -= amount
+                expenses.append({
+                    "date": txn.get("transaction_date"),
+                    "amount": -amount,  # Show as negative to indicate refund
+                    "content": txn.get("content", ""),
+                    "type": "in"
                 })
 
         # Format response


### PR DESCRIPTION
- 'in' transactions with category 'Income' are now tracked as income
- 'in' transactions with other categories now reduce expenses (refunds/returns)
- 'out' transactions continue to add to expenses as before
- In /category view, refunds are displayed with negative amounts for clarity

This ensures proper budget tracking where refunds reduce spending and income is tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)